### PR TITLE
Add ffaker dependency to gemspec

### DIFF
--- a/solidus_product_feed.gemspec
+++ b/solidus_product_feed.gemspec
@@ -27,5 +27,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'factory_girl_rails'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'faker'
+  s.add_development_dependency 'ffaker'
   s.add_development_dependency 'sqlite3'
 end


### PR DESCRIPTION
ffaker is needed for Solidus' factories.

ffaker was removed as a runtime dependency of Solidus here:
https://github.com/solidusio/solidus/pull/2163