### PR TITLE
Make feed headers configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,32 @@ $ bundle install
 
 You're done! You can now see your RSS feed at `/products.rss`.
 
+## Usage
+
+The RSS feed is configured wih some sensible defaults, but you can easily change them by putting
+the following in your Rails initializer:
+
+```ruby
+SolidusProductFeed.configure do |config|
+  config.title = 'My Awesome Store'
+  config.link = 'https://www.awesomestore.com'
+  config.description = 'Find out about new products on https://www.awesomestore.com first!'
+  config.language = 'en-us'
+end
+```
+
+Note that you can also pass a Proc for each of these options. The Proc will be passed the view
+context as its only argument, so that you can use any helpers:
+
+```ruby
+SolidusProductFeed.configure do |config|
+  config.title = -> (view) { view.current_store.name }
+  config.link = -> (view) { "http://#{view.current_store.url}" }
+  config.description = -> (view) { "Find out about new products on http://#{view.current_store.url} first!" }
+  config.language = -> (view) { view.lang_from_store(current_store.language) }
+end
+```
+
 ## Testing
 
 Be sure to add the `rspec-rails` gem to your Gemfile and then create a dummy test app for the specs 

--- a/README.md
+++ b/README.md
@@ -1,44 +1,44 @@
-Solidus Product Feed
-================
+# Solidus Product Feed
 
 [![Build Status](https://travis-ci.org/solidusio-contrib/solidus_product_feed.svg?branch=master)](https://travis-ci.org/solidusio-contrib/solidus_product_feed)
 
-An extension that provides an RSS feed for products. Google Shopper attributes are also implemented.
-An RSS link is automatically appended to the `<head>` tag in the `layouts/spree_application` file.
+An extension that provides an RSS feed for products. Google Merchant Feed attributes are also
+implemented. An RSS link is automatically appended to the `<head>` tag in the
+`layouts/spree_application` file.
 
-Note on Versions
-================
+## Note on Versions
 
-The master branch tracks the 1.0 version of this gem, which has some major changes from it's predecessor `spree_product_feed`.
-The 1.0 version is cleaner, more extensible, and more correct at the expense of compatibility.
+The master branch tracks the 1.0 version of this gem, which has some major changes from its
+predecessor `spree_product_feed`. The 1.0 version is cleaner, more extensible, and more correct at 
+the expense of compatibility.
 
-We also have a [`~> 0.1.0` version](https://github.com/solidusio-contrib/solidus_product_feed/tree/v0.1) which is a direct port of `spree_product_feed` with minimal changes.
+We also have a [`~> 0.1.0` version](https://github.com/solidusio-contrib/solidus_product_feed/tree/v0.1) 
+which is a direct port of `spree_product_feed` with minimal changes.
 
+## Installation
 
-Installation
-===============
+Add the gem to your `Gemfile`:
 
-1) add the gem to your `Gemfile`:
+```ruby
+gem 'solidus_product_feed'
+````
 
-`gem 'solidus_product_feed'`
+Install the gem:
 
-2) run bundler:
+```console
+$ bundle install
+```
 
-`bundle install`
+You're done! You can now see your RSS feed at `/products.rss`.
 
-3) BOOOM, you're done
+## Testing
 
-Viewing Product RSS
-============
+Be sure to add the `rspec-rails` gem to your Gemfile and then create a dummy test app for the specs 
+to run against.
 
-`http://yourdomain.tld/products.rss`
-
-Testing
-=======
-
-Be sure to add the rspec-rails gem to your Gemfile and then create a dummy test app for the specs to run against.
-
-    $ bundle exec rake test app
-    $ bundle exec rspec spec
+```console
+$ bundle exec rake test app
+$ bundle exec rspec spec
+```
 
 Copyright (c) 2011 Joshua Nussbaum, released under the New BSD License

--- a/app/views/spree/products/index.rss.builder
+++ b/app/views/spree/products/index.rss.builder
@@ -2,10 +2,10 @@ xml.instruct! :xml, version: "1.0"
 
 xml.rss version: "2.0", "xmlns:g" => "http://base.google.com/ns/1.0" do
   xml.channel do
-    xml.title current_store.name
-    xml.link "http://#{current_store.url}"
-    xml.description "Find out about new products on http://#{current_store.url} first!"
-    xml.language 'en-us'
+    xml.title SolidusProductFeed.evaluate(SolidusProductFeed.title, self)
+    xml.link SolidusProductFeed.evaluate(SolidusProductFeed.link, self)
+    xml.description SolidusProductFeed.evaluate(SolidusProductFeed.description, self)
+    xml.language SolidusProductFeed.evaluate(SolidusProductFeed.language, self)
 
     @feed_products.each do |feed_product|
       xml.item do

--- a/lib/solidus_product_feed.rb
+++ b/lib/solidus_product_feed.rb
@@ -1,2 +1,32 @@
 require 'spree_core'
 require 'solidus_product_feed/engine'
+
+module SolidusProductFeed
+  class << self
+    attr_writer :title, :link, :description, :language
+
+    def configure
+      yield self
+    end
+
+    def evaluate(value, view_context)
+      value.respond_to?(:call) ? value.call(view_context) : value
+    end
+
+    def title
+      @title ||= -> (view) { view.current_store.name }
+    end
+
+    def link
+      @link ||= -> (view) { "http://#{view.current_store.url}" }
+    end
+
+    def description
+      @description ||= -> (view) { "Find out about new products on http://#{view.current_store.url} first!" }
+    end
+
+    def language
+      @language ||= 'en-us'
+    end
+  end
+end


### PR DESCRIPTION
Adds the ability to configure `title`, `link`, `description` and `language` by either providing a literal or a Proc that gets `instance_exec`d in the view context.

Also updates the readme with this information and adjusts the formatting a little bit.