### PR TITLE
Dynamic schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,11 @@ You're done! You can now see your RSS feed at `/products.rss`.
 
 ## Usage
 
-The RSS feed is configured wih some sensible defaults, but you can easily change them by putting
-the following in your Rails initializer:
+The feed ships with sensible defaults for your products, but customization is very easy.
+
+### Headers
+
+You can easily change the feed's headers by putting the following in your Rails initializer:
 
 ```ruby
 SolidusProductFeed.configure do |config|
@@ -46,7 +49,7 @@ end
 ```
 
 Note that you can also pass a Proc for each of these options. The Proc will be passed the view
-context as its only argument, so that you can use any helpers:
+context as its only argument, so that you can use all your helpers:
 
 ```ruby
 SolidusProductFeed.configure do |config|
@@ -56,6 +59,33 @@ SolidusProductFeed.configure do |config|
   config.language = -> (view) { view.lang_from_store(current_store.language) }
 end
 ```
+
+### Item schema
+
+If you need to alter the XML schema of a product (e.g. to add/remove a tag), you can do it by
+subclassing `Spree::FeedProduct` in your app and overriding the `schema` method:
+
+```ruby
+module AwesomeStore
+  class FeedProduct < Spree::FeedProduct
+    def schema
+      super.merge('g:brand' => 'Awesome Store Inc.')
+    end
+  end
+end
+```
+
+Then set your custom class in an initializer:
+
+```ruby
+SolidusProductFeed.configure do |config|
+  config.feed_product_class = 'AwesomeStore::FeedProduct'
+end
+```
+
+If you want to change the value of an existing tag, you can also simply override the corresponding
+tag method (`link`, `price` etc.). Check the [source code](https://github.com/solidusio-contrib/solidus_product_feed/blob/master/app/models/spree/feed_product.rb)
+for more details. 
 
 ## Testing
 

--- a/app/controllers/spree/products_controller_decorator.rb
+++ b/app/controllers/spree/products_controller_decorator.rb
@@ -13,6 +13,6 @@ Spree::ProductsController.prepend(Module.new do
   private
 
   def load_feed_products
-    @feed_products = Spree::Product.all.map(&Spree::FeedProduct.method(:new))
+    @feed_products = Spree::Product.all.map(&SolidusProductFeed.feed_product_class.method(:new))
   end
 end)

--- a/app/models/spree/feed_product.rb
+++ b/app/models/spree/feed_product.rb
@@ -6,6 +6,22 @@ module Spree
       @product = product
     end
 
+    def schema
+      {
+        'g:id' => id,
+        'title' => title,
+        'description' => description,
+        'link' => link,
+        'g:image_link' => image_link,
+        'g:condition' => condition,
+        'g:price' => price,
+        'g:availability' => availability,
+        'g:brand' => brand,
+        'g:mpn' => mpn,
+        'category' => category,
+      }
+    end
+
     def id
       product.id
     end
@@ -18,18 +34,8 @@ module Spree
       product.description
     end
 
-    # Must be selected from https://support.google.com/merchants/answer/1705911
-    def category; end
-
-    def brand; end
-
-    # Must be "new", "refurbished", or "used".
-    def condition
-      "new"
-    end
-
-    def price
-      Spree::Money.new(product.price)
+    def link
+      -> (view) { view.product_url(product) }
     end
 
     def image_link
@@ -38,12 +44,27 @@ module Spree
       product.images.first.attachment.url(:large)
     end
 
+    # Must be "new", "refurbished", or "used".
+    def condition
+      "new"
+    end
+
+    def price
+      Spree::Money.new(product.price).money.format(symbol: false, with_currency: true)
+    end
+
     def availability
       product.master.in_stock? ? 'in stock' : 'out of stock'
     end
 
+    def brand; end
+
     def mpn
       product.master.sku
+    end
+
+    def category
+      # Must be selected from https://support.google.com/merchants/answer/1705911
     end
   end
 end

--- a/app/views/spree/products/index.rss.builder
+++ b/app/views/spree/products/index.rss.builder
@@ -9,17 +9,10 @@ xml.rss version: "2.0", "xmlns:g" => "http://base.google.com/ns/1.0" do
 
     @feed_products.each do |feed_product|
       xml.item do
-        xml.tag! 'g:id', feed_product.id
-        xml.title feed_product.title
-        xml.description feed_product.description
-        xml.category feed_product.category if feed_product.category
-        xml.link product_url(feed_product.product)
-        xml.tag! 'g:image_link', feed_product.image_link
-        xml.tag! 'g:condition', feed_product.condition
-        xml.tag! 'g:price', feed_product.price.money.format(symbol: false, with_currency: true)
-        xml.tag! 'g:availability', feed_product.availability
-        xml.tag! 'g:brand', feed_product.brand
-        xml.tag! 'g:mpn', feed_product.mpn
+        feed_product.schema.each_pair do |tag, value|
+          value = value.call(self) if value.respond_to?(:call)
+          xml.tag! tag, value
+        end
       end
     end
   end

--- a/lib/solidus_product_feed.rb
+++ b/lib/solidus_product_feed.rb
@@ -3,7 +3,7 @@ require 'solidus_product_feed/engine'
 
 module SolidusProductFeed
   class << self
-    attr_writer :title, :link, :description, :language
+    attr_writer :title, :link, :description, :language, :feed_product_class
 
     def configure
       yield self
@@ -27,6 +27,10 @@ module SolidusProductFeed
 
     def language
       @language ||= 'en-us'
+    end
+
+    def feed_product_class
+      (@feed_product_class ||= 'Spree::FeedProduct').constantize
     end
   end
 end

--- a/spec/models/spree/feed_product_spec.rb
+++ b/spec/models/spree/feed_product_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Spree::FeedProduct do
 
   describe "#price" do
     subject { feed_product.price }
-    it { is_expected.to eq Spree::Money.new(19.99, currency: 'USD') }
+    it { is_expected.to eq '19.99 USD' }
   end
 
   describe "#image_link" do


### PR DESCRIPTION
This allows users to alter the schema of the RSS feed without touching the underlying view, by embedding the schema entirely in the `schema` method on `Spree::FeedProduct`.

It also makes the name of the `Spree::FeedProduct` class itself configurable, so that it can be subclassed and altered without having to use `prepend`.