### PR TITLE
Verify Request Format

### DIFF
--- a/app/decorators/solidus_product_feed/spree/products_controller_decorator.rb
+++ b/app/decorators/solidus_product_feed/spree/products_controller_decorator.rb
@@ -5,6 +5,7 @@ module SolidusProductFeed
     module ProductsControllerDecorator
       def self.prepended(klass)
         klass.respond_to :rss, only: :index
+        klass.before_action :verify_requested_format!, only: :index
       end
 
       def index

--- a/spec/controllers/products_controller_spec.rb
+++ b/spec/controllers/products_controller_spec.rb
@@ -19,4 +19,14 @@ describe Spree::ProductsController, type: :controller do
       expect(response.content_type.split(';').first).to eq 'application/rss+xml'
     end
   end
+
+  context 'GET #index with weirdo formats' do
+    subject { get :index, params: { format: 'wat' } }
+
+    let!(:product) { create :product, name: "2 Hams", price: 20.00 }
+
+    it "raises ActionController::UnkownFormat" do
+      expect { subject }.to raise_exception(ActionController::UnknownFormat)
+    end
+  end
 end


### PR DESCRIPTION
The responders gem will somehow try rendering the `rss.builder` partial
even if you speficy `wat` as a format. They have a request format
verification method that throws `ActionController::UnknownFormat`
instead of the `NoMethodError` that occurs when trying to render the
partial without loading the Feed Products first.