### PR TITLE
Remove storefront Deface override

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 [![CircleCI](https://circleci.com/gh/solidusio-contrib/solidus_product_feed.svg?style=svg)](https://circleci.com/gh/solidusio-contrib/solidus_product_feed)
 
 An extension that provides an RSS feed for products. Google Merchant Feed attributes are also
-implemented. An RSS link is automatically appended to the `<head>` tag in the
-`layouts/spree_application` file.
+implemented.
 
 ## Installation
 
@@ -77,6 +76,15 @@ end
 If you want to change the value of an existing tag, you can also simply override the corresponding
 tag method (`link`, `price` etc.). Check the [source code](https://github.com/solidusio-contrib/solidus_product_feed/blob/master/app/models/spree/feed_product.rb)
 for more details. 
+
+### Making your feed discoverable
+
+If you want to make your feed discoverable when visiting your store, simply add the following to
+your storefront's `head`:
+
+```html
+<%= auto_discovery_link_tag(:rss, products_path(format: :rss), title: "My Store's Products") %>
+```
 
 ## Testing
 

--- a/app/overrides/rss_link.rb
+++ b/app/overrides/rss_link.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-Deface::Override.new(virtual_path: 'layouts/spree_application',
-                     name: 'product_rss_link',
-                     original: '86987c7feaaea3181df195ca520571d801bbbaf3',
-                     insert_bottom: "[data-hook='inside_head']",
-                     text: '<%= auto_discovery_link_tag(:rss, products_path(:format => :rss), {:title => "#{Spree::Config[:site_title]} Products"}) %>')

--- a/lib/solidus_product_feed.rb
+++ b/lib/solidus_product_feed.rb
@@ -6,8 +6,6 @@ require 'solidus_support'
 require 'solidus_product_feed/version'
 require 'solidus_product_feed/engine'
 
-require 'deface'
-
 module SolidusProductFeed
   class << self
     attr_writer :title, :link, :description, :language, :feed_product_class

--- a/solidus_product_feed.gemspec
+++ b/solidus_product_feed.gemspec
@@ -29,7 +29,6 @@ Gem::Specification.new do |spec|
   spec.executables = files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'deface'
   spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 3']
   spec.add_dependency 'solidus_support', '~> 0.5'
 


### PR DESCRIPTION
Removes the Deface override that added the RSS feed link to the storefront's `head`. This may not be desirable in all situations, and in general we discourage extensions from customizing the storefront directly.